### PR TITLE
Add preset-driven entry point with mode folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 **/.DS_Store
 calendar.pdf
+__pycache__/
+*.pyc

--- a/main.py
+++ b/main.py
@@ -1,0 +1,38 @@
+import argparse
+from typing import Dict, Callable
+
+import yaml
+
+from mode import weekly
+
+MODE_GENERATORS: Dict[str, Callable[[str, str], None]] = {
+    "weekly": weekly.generate,
+}
+
+
+def _load_preset(path: str) -> Dict[str, str]:
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    if not isinstance(data, dict):
+        raise ValueError("Preset file must define a mapping of options")
+    return {str(k): str(v) for k, v in data.items()}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate a calendar PDF.")
+    parser.add_argument("--preset", required=True, help="Path to YAML preset file")
+    parser.add_argument("--start_date", required=True, help="Start date in YYYY/MM/DD format")
+    parser.add_argument("--end_date", required=True, help="End date in YYYY/MM/DD format")
+    args = parser.parse_args()
+
+    config = _load_preset(args.preset)
+    mode_name = config.get("mode")
+    generator = MODE_GENERATORS.get(mode_name)
+    if generator is None:
+        raise ValueError(f"Unsupported mode: {mode_name}")
+
+    generator(args.start_date, args.end_date)
+
+
+if __name__ == "__main__":
+    main()

--- a/mode/weekly.py
+++ b/mode/weekly.py
@@ -1,11 +1,11 @@
 import datetime
-import argparse
 from reportlab.lib.pagesizes import letter, landscape
 from reportlab.lib import colors
 from reportlab.pdfgen import canvas
 from reportlab.lib.units import inch
 
-def round_to_week(start_date, end_date):
+
+def _round_to_week(start_date: datetime.date, end_date: datetime.date):
     start_weekday = start_date.weekday()
     if start_weekday != 6:
         start_date -= datetime.timedelta(days=(start_weekday + 1) % 7)
@@ -14,10 +14,11 @@ def round_to_week(start_date, end_date):
         end_date += datetime.timedelta(days=(5 - end_weekday + 7) % 7)
     return start_date, end_date
 
-def generate_weekly_calendar(start_date_str, end_date_str):
+
+def generate(start_date_str: str, end_date_str: str) -> None:
     start_date = datetime.datetime.strptime(start_date_str, "%Y/%m/%d").date()
     end_date = datetime.datetime.strptime(end_date_str, "%Y/%m/%d").date()
-    start_date, end_date = round_to_week(start_date, end_date)
+    start_date, end_date = _round_to_week(start_date, end_date)
 
     c = canvas.Canvas("calendar.pdf", pagesize=landscape(letter))
     width, height = landscape(letter)
@@ -80,11 +81,3 @@ def generate_weekly_calendar(start_date_str, end_date_str):
 
     c.save()
     print("calendar.pdf generated successfully!")
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Generate a weekly calendar PDF.")
-    parser.add_argument("start_date", help="Start date in YYYY/MM/DD format")
-    parser.add_argument("end_date", help="End date in YYYY/MM/DD format")
-    args = parser.parse_args()
-
-    generate_weekly_calendar(args.start_date, args.end_date)

--- a/preset_weekly.yaml
+++ b/preset_weekly.yaml
@@ -1,0 +1,1 @@
+mode: weekly

--- a/requirement.txt
+++ b/requirement.txt
@@ -1,0 +1,2 @@
+reportlab
+pyyaml


### PR DESCRIPTION
## Summary
- rename `generate_calendar.py` to `main.py` and support `--preset` YAML config for modes
- move weekly calendar generator into `mode/weekly.py`
- parse presets with PyYAML and add `pyyaml` to `requirement.txt`
- sample `preset_weekly.yaml` to trigger weekly mode

## Testing
- `pip3 install -r requirement.txt`
- `python3 main.py --preset preset_weekly.yaml --start_date 2024/01/01 --end_date 2024/01/31`


------
https://chatgpt.com/codex/tasks/task_e_68bbcc0fd54483228ff25e83c515641f